### PR TITLE
Fix training speed benchmarks

### DIFF
--- a/training_speed/experiments.py
+++ b/training_speed/experiments.py
@@ -117,9 +117,9 @@ EXPERIMENT_TYPE = {
 
 EXPERIMENTS = {
     name: Experiment(name, experiment_type[0], experiment_type[1])
-    for name, experiment_type in EXPERIMENT_TYPE.iteritems()
+    for name, experiment_type in EXPERIMENT_TYPE.items()
 }
 
 
 def params_to_str(params):
-    return ''.join(map(lambda (key, value): '{}[{}]'.format(key, str(value)), params.items()))
+    return ''.join(map(lambda item: '{}[{}]'.format(item[0], str(item[1])), params.items()))


### PR DESCRIPTION
`training_speed/experiments.py` uses Python 2 syntax, while the rest of the training benchmark use Python 3.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en